### PR TITLE
fix: add openssl deps and pipefail to catch silent build failures

### DIFF
--- a/asahi-fairydust-build.sh
+++ b/asahi-fairydust-build.sh
@@ -36,7 +36,7 @@
 #   - This script is provided as-is with no warranty
 # =============================================================================
 
-set -e
+set -eo pipefail
 
 # --- Configuration ---
 CLONE_DIR="$HOME/linux-fairydust"
@@ -145,6 +145,7 @@ install_deps() {
         gcc gcc-c++ make bc bison flex elfutils-libelf-devel \
         ncurses-devel python3 zlib-devel libuuid-devel dwarves \
         xz zstd clang llvm lld git \
+        openssl openssl-devel \
         rust rust-std-static bindgen-cli \
         2>&1 | tee -a "$LOG_FILE"
 
@@ -306,7 +307,7 @@ build_kernel() {
 
     cd "$CLONE_DIR"
 
-    make -j$(nproc) 2>&1 | tee -a "$LOG_FILE"
+    log_and_run make -j$(nproc)
 
     ok "Kernel build completed at: $(date)"
 }
@@ -323,20 +324,20 @@ install_kernel() {
 
     # Install modules, DTBs, VDSO
     info "Installing modules..."
-    sudo make INSTALL_MOD_STRIP=1 modules_install 2>&1 | tee -a "$LOG_FILE"
+    log_and_run sudo make INSTALL_MOD_STRIP=1 modules_install
 
     info "Installing DTBs..."
-    sudo make dtbs_install 2>&1 | tee -a "$LOG_FILE"
+    log_and_run sudo make dtbs_install
 
     info "Installing VDSO..."
-    sudo make vdso_install 2>&1 | tee -a "$LOG_FILE"
+    log_and_run sudo make vdso_install
 
     # Create DTB symlink that Fedora expects
     sudo ln -sf "/boot/dtbs/$KVER" "/usr/lib/modules/$KVER/dtb"
 
     # Install kernel image
     info "Installing kernel image..."
-    sudo make install 2>&1 | tee -a "$LOG_FILE"
+    log_and_run sudo make install
 
     ok "Kernel installed: $KVER"
 }


### PR DESCRIPTION
Fixes two bugs that cause silent build failures.

## Bug 1 — `openssl` / `openssl-devel` missing from `install_deps`

The kernel build calls `openssl` to generate `certs/signing_key.pem`. Without the package on `PATH` the step exits with `Error 127`, but because of Bug 2 the script continued anyway and the failure was invisible.

**Fix:** add `openssl openssl-devel` to the `sudo dnf install -y` block in `install_deps`.

## Bug 2 — `set -e` without `pipefail` lets `make | tee` swallow failures

In `build_kernel` and `install_kernel` every `make` invocation was piped directly through `tee`:

```bash
make -j$(nproc) 2>&1 | tee -a "$LOG_FILE"
sudo make modules_install 2>&1 | tee -a "$LOG_FILE"
# … etc.
```

With `set -e` but without `pipefail`, bash checks only `tee`'s exit code (almost always 0). A failing `make` therefore never triggers `set -e` and the script proceeds silently.

The script already has a correct `log_and_run` helper that returns `${PIPESTATUS[0]}`, but it wasn't used in these two functions.

**Fix:**
- `set -e` → `set -eo pipefail` at the top of the script.
- Replace every `make ... 2>&1 | tee -a "$LOG_FILE"` in `build_kernel` and `install_kernel` with `log_and_run make ...`.

## Test environment

MacBookPro17,1 · Apple M1 · Fedora Asahi Remix 43

Closes #1