### PR TITLE
chore: optimize cloning time, by adding --depth 1

### DIFF
--- a/asahi-fairydust-build.sh
+++ b/asahi-fairydust-build.sh
@@ -200,7 +200,7 @@ clone_source() {
     fi
 
     git clone https://github.com/AsahiLinux/linux.git \
-        --branch "$BRANCH" --single-branch "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE"
+        --branch "$BRANCH" --depth 1 --single-branch "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE"
 
     cd "$CLONE_DIR"
     ok "Source cloned to $CLONE_DIR"


### PR DESCRIPTION
Drastically reduce the cloning time, by specifying --depth 1

Fetching the whole commit history takes a long time on the kernel (It took 1+ hours on an M1 mac, and is probably unnecessary) 