### PR TITLE
fix: disable display-setup helper to avoid login loop on KDE/Wayland

### DIFF
--- a/asahi-fairydust-build.sh
+++ b/asahi-fairydust-build.sh
@@ -509,7 +509,7 @@ main() {
     update_m1n1
     update_grub
     setup_modules
-    setup_display_script
+    # setup_display_script  # disabled: causes login loop on KDE/Wayland sessions. X11 users can call manually.
     print_summary
 }
 


### PR DESCRIPTION
## Symptom

Multiple users hit a login loop after running the script, most recently reported on r/AsahiLinux: https://www.reddit.com/r/AsahiLinux/comments/1timga9/comment/on4ez0j/

Confirmed on KDE Plasma (Fedora 44, SDDM/Wayland).

## Root cause

`setup_display_script` installs three artifacts:

1. `~/display-setup.sh` — xrandr-based helper
2. `~/.config/autostart/fairydust-display.desktop` — runs the helper at login
3. `/etc/udev/rules.d/95-fairydust-hotplug.rules` — `RUN+=` on every DRM change

The udev rule is the smoking gun. `RUN+=` is **synchronous** — it blocks the udev worker until the command exits. The helper opens with `sleep 2` and then calls xrandr, which can't connect on Wayland (no X server at `:0`) and competes with the compositor for display state on X11.

On KDE Plasma startup, DRM change events pile up behind the blocking helper, display init times out, the session aborts, SDDM bounces back to the greeter, the next login produces the same DRM events → loop.

## Fix

Comment out the `setup_display_script` call from `main()`. One-line diff. The function is left defined so X11 users who want the helper can call it manually after install.

## Why removing it is safe

With current fairydust + Wayland (GNOME or KDE), the kernel exposes the USB-C connector and the compositor handles display arrangement natively. As Phaestion notes in the Reddit thread: *"All functionality of USB C monitors work fine even without the script."* The helper is X11-era vestige.

## Tested on

MacBook Pro 13" M1 (j293/t8103), Fedora Asahi Remix 43, kernel 6.19.14-fairydust+, GNOME/GDM (Wayland).

- With the unpatched script (`setup_display_script` enabled): ran for months, never hit the login loop. The bug appears specific to SDDM/Plasma rather than all of Wayland.
- With the helper disabled (this patch): displays still work correctly via the compositor — confirms the helper is unnecessary on Wayland.