### PR TITLE
Fix rust/core.o build failure, plus unattended and fork-friendly builds

### DIFF
--- a/asahi-fairydust-build.sh
+++ b/asahi-fairydust-build.sh
@@ -39,9 +39,14 @@
 set -eo pipefail
 
 # --- Configuration ---
-CLONE_DIR="$HOME/linux-fairydust"
-BRANCH="fairydust"
-LOCALVERSION="-fairydust"
+# All of these can be overridden from the environment, which makes it possible
+# to build a branch that carries extra patches without editing this script:
+#   REPO_URL=https://github.com/you/linux.git BRANCH=my-branch ./asahi-fairydust-build.sh
+REPO_URL="${REPO_URL:-https://github.com/AsahiLinux/linux.git}"
+CLONE_DIR="${CLONE_DIR:-$HOME/linux-fairydust}"
+BRANCH="${BRANCH:-fairydust}"
+LOCALVERSION="${LOCALVERSION:--fairydust}"
+JOBS="${JOBS:-$(nproc)}"
 DISPLAY_SCRIPT="$HOME/display-setup.sh"
 LOG_FILE="$HOME/fairydust-build.log"
 
@@ -207,19 +212,24 @@ clone_source() {
     echo ""
     info "=== Step 2/9: Cloning fairydust kernel source ==="
 
-    if [[ -d "$CLONE_DIR" ]]; then
-        warn "Directory $CLONE_DIR already exists."
-        if confirm "Delete and re-clone?"; then
-            rm -rf "$CLONE_DIR"
-        else
-            info "Using existing source tree."
-            cd "$CLONE_DIR"
-            return
+    if [[ -d "$CLONE_DIR/.git" ]]; then
+        info "Using existing source tree at $CLONE_DIR"
+        cd "$CLONE_DIR"
+        # Make sure we are actually on the branch we intend to build.
+        if [[ "$(git branch --show-current)" != "$BRANCH" ]]; then
+            info "Checking out $BRANCH"
+            git checkout "$BRANCH" 2>&1 | tee -a "$LOG_FILE"
         fi
+        ok "Branch: $(git branch --show-current)"
+        info "HEAD:   $(git log --oneline -1)"
+        return
     fi
 
-    git clone https://github.com/AsahiLinux/linux.git \
-        --branch "$BRANCH" --depth 1 --single-branch "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE"
+    # A blobless clone is about the same size as --depth 1 for a checkout, but
+    # keeps history, so the tree stays usable for rebasing local patches onto
+    # a newer upstream instead of having to re-clone.
+    git clone "$REPO_URL" --branch "$BRANCH" --single-branch \
+        --filter=blob:none "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE"
 
     cd "$CLONE_DIR"
     ok "Source cloned to $CLONE_DIR"
@@ -330,12 +340,12 @@ See Documentation/rust/quick-start.rst in the kernel source."
 build_kernel() {
     echo ""
     info "=== Step 4/9: Building kernel (this will take a while) ==="
-    info "Using $(nproc) parallel jobs"
+    info "Using $JOBS parallel jobs"
     info "Started at: $(date)"
 
     cd "$CLONE_DIR"
 
-    log_and_run make -j$(nproc)
+    log_and_run make -j$JOBS
 
     ok "Kernel build completed at: $(date)"
 }

--- a/asahi-fairydust-build.sh
+++ b/asahi-fairydust-build.sh
@@ -45,6 +45,19 @@ LOCALVERSION="-fairydust"
 DISPLAY_SCRIPT="$HOME/display-setup.sh"
 LOG_FILE="$HOME/fairydust-build.log"
 
+# Prefer the distro Rust toolchain over anything rustup installed.
+#
+# The kernel compiles the Rust core library from source, so rustc and the
+# rust-src tree must be the same version. A rustup toolchain in ~/.cargo/bin
+# takes precedence on PATH and is usually a different version from the
+# rust-src RPM, which makes rust/core.o fail to build with errors like
+# "attributes starting with `rustc` are reserved" and
+# "cannot use `const` closures outside of const contexts".
+if [[ -x /usr/bin/rustc && -d /usr/lib/rustlib/src/rust/library ]]; then
+    export PATH="/usr/bin:$PATH"
+    export RUST_LIB_SRC="/usr/lib/rustlib/src/rust/library"
+fi
+
 # --- Colors ---
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/asahi-fairydust-build.sh
+++ b/asahi-fairydust-build.sh
@@ -78,6 +78,12 @@ log_and_run() {
 }
 
 confirm() {
+    # ASSUME_YES lets the build run unattended. NO_REBOOT is handled separately
+    # so that an unattended run never reboots the machine by itself.
+    if [[ "${ASSUME_YES:-0}" == "1" ]]; then
+        info "$1 [auto-yes]"
+        return 0
+    fi
     read -rp "$(echo -e "${YELLOW}$1 [y/N]:${NC} ")" response
     [[ "$response" =~ ^[Yy]$ ]]
 }
@@ -504,7 +510,9 @@ print_summary() {
     echo "============================================================"
     echo ""
 
-    if confirm "Reboot now?"; then
+    if [[ "${NO_REBOOT:-0}" == "1" ]]; then
+        info "NO_REBOOT is set. Reboot when ready with: sudo reboot"
+    elif confirm "Reboot now?"; then
         sudo reboot
     else
         info "Reboot when ready with: sudo reboot"


### PR DESCRIPTION
Ran this on a MacBook Pro 14-inch M1 Pro (`apple,j314s`) on Fedora Asahi Remix 44 and hit one hard build failure. Fixed that, then made a couple of changes that made the rest of the process easier. Defaults are unchanged throughout, so existing usage behaves exactly as before.

### 1. `rust/core.o` fails when rustup is installed

This was a hard stop about ten minutes into the build:

```
error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
error: cannot find attribute `rustc_no_writable` in this scope
error: cannot use `const` closures outside of const contexts
error: the compiler unexpectedly panicked. This is a bug
make[2]: *** [rust/Makefile:654: rust/core.o] Error 101
```

The kernel compiles the Rust core library from source, so `rustc` and the `rust-src` tree have to be the same version. On my machine:

- `rust-src` RPM: 1.97.1
- `rustc` first on PATH: **1.96.0**, from `~/.cargo/bin/rustc`

The script's own rustup fallback had installed that 1.96.0 toolchain, and `~/.cargo/bin` precedes `/usr/bin` on PATH, so it won. 1.97.1 core sources were being compiled by a 1.96.0 compiler.

Anyone who has ever run rustup for unrelated reasons will hit this. Fixed by pinning `PATH` and `RUST_LIB_SRC` to the distro toolchain when it is present.

### 2. `ASSUME_YES` / `NO_REBOOT`

The build takes hours, so it wants to run unattended. `ASSUME_YES=1` answers the confirmation prompts. `NO_REBOOT=1` is deliberately a separate switch, so an unattended run can never reboot the machine on its own after installing the kernel.

### 3. Fork-friendly config, and a less destructive clone step

`REPO_URL`, `CLONE_DIR`, `BRANCH`, `LOCALVERSION` and `JOBS` are now environment-overridable. That makes it possible to build a branch carrying extra patches without editing the script:

```bash
REPO_URL=https://github.com/you/linux.git BRANCH=my-branch ./asahi-fairydust-build.sh
```

Two related changes in `clone_source`:

- An existing checkout is reused rather than offering to delete it, and the requested branch is checked out if the tree is on a different one. Deleting a tree that may hold local commits felt like the wrong default.
- `--filter=blob:none` instead of `--depth 1`. The checkout ends up about the same size, but history is kept, so the tree can be rebased onto a newer upstream instead of re-cloned.

`JOBS` also helps on machines where a full `-j$(nproc)` would exhaust RAM. Mine has 16 GB and needed `-j6`.

### Testing

Full build, install and reboot on M1 Pro 14-inch, Fedora Asahi Remix 44, kernel 7.0.13. Build completed in about 2h20m at `-j6`, GPU came up as `Apple M1 Pro (G13S C0)` rather than llvmpipe, and both stock kernels stayed bootable in GRUB.

Thanks for writing this, it saved me a lot of guesswork on the config side.