### PR TITLE
Add patches/ support and fix built-in HDMI staying dark after suspend

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,44 @@ chmod +x asahi-fairydust-build.sh
 
 1. Installs build dependencies (gcc, Rust toolchain, etc.)
 2. Clones the Asahi Linux `fairydust` kernel branch
-3. Configures the kernel with your existing Fedora config as baseline
-4. Enables Rust support + Asahi GPU driver (prevents lag)
-5. Enables USB-C DisplayPort Alt Mode modules
-6. Builds the kernel (~60-90 min)
-7. Installs kernel, modules, and device tree blobs
-8. Updates m1n1 bootloader and GRUB
-9. Sets up automatic typec module loading
-10. Creates a display hotplug script for automatic configuration
+3. Applies the patches in `patches/` (see below)
+4. Configures the kernel with your existing Fedora config as baseline
+5. Enables Rust support + Asahi GPU driver (prevents lag)
+6. Enables USB-C DisplayPort Alt Mode modules
+7. Builds the kernel (~60-90 min)
+8. Installs kernel, modules, and device tree blobs
+9. Updates m1n1 bootloader and GRUB
+10. Sets up automatic typec module loading
+11. Creates a display hotplug script for automatic configuration
+
+## Patches
+
+Everything in `patches/*.patch` is applied to the branch in filename order
+before the kernel is configured. Already-applied patches are skipped, so
+re-running against an existing checkout is safe. To build the branch
+untouched:
+
+```bash
+SKIP_PATCHES=1 ./asahi-fairydust-build.sh
+```
+
+### `0001-drm-apple-reconnect-DP2HDMI-output-on-resume.patch`
+
+Fixes the built-in HDMI port staying dark after suspend/resume on Macs that
+have one, where the only recovery is unplugging and replugging the cable.
+
+`dcp_platform_suspend()` disables the HPD interrupt and tears the DPTX link
+down. `dcp_platform_resume()` only re-enables the interrupt. That interrupt is
+edge triggered, so a display left plugged in across suspend produces no edge,
+the handler never runs, and nothing calls `dcp_dptx_connect()` again.
+
+The driver already has the right helper — `dcp_enable_dp2hdmi_hpd()` samples
+the HPD GPIO, reconnects if a display is present, then enables the interrupt,
+which is what `dcp_wait_ready()` already does. Resume just wasn't calling it.
+
+Verified on a MacBook Pro 14-inch M1 Pro (`apple,j314s`), kernel 7.0.13. If it
+ever stops applying, the change has most likely landed upstream and the file
+can be deleted.
 
 ## Important Notes
 

--- a/asahi-fairydust-build.sh
+++ b/asahi-fairydust-build.sh
@@ -38,6 +38,12 @@
 
 set -eo pipefail
 
+# Resolved once, before anything changes directory. ${BASH_SOURCE[0]} is the
+# path used to invoke the script, so for the usual ./asahi-fairydust-build.sh
+# it is relative; resolving it after clone_source has cd'd into the kernel tree
+# would silently yield the kernel tree instead.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
 # --- Configuration ---
 CLONE_DIR="$HOME/linux-fairydust"
 BRANCH="fairydust"
@@ -206,6 +212,49 @@ clone_source() {
     ok "Source cloned to $CLONE_DIR"
     info "Branch: $(git branch --show-current)"
     info "HEAD:   $(git log --oneline -1)"
+}
+
+# --- Apply local patches on top of the branch ---
+#
+# Anything in patches/*.patch is applied in filename order. Patches that are
+# already present in the tree are skipped, so re-running the script on an
+# existing checkout is safe. Set SKIP_PATCHES=1 to build the branch untouched.
+apply_patches() {
+    local patch_dir
+    patch_dir="$SCRIPT_DIR/patches"
+
+    if [[ "${SKIP_PATCHES:-0}" == "1" ]]; then
+        info "SKIP_PATCHES is set, building the branch as-is"
+        return
+    fi
+
+    if [[ ! -d "$patch_dir" ]] || ! compgen -G "$patch_dir/*.patch" >/dev/null; then
+        info "No patches to apply"
+        return
+    fi
+
+    cd "$CLONE_DIR" || error "Source tree missing at $CLONE_DIR"
+
+    local p
+    for p in "$patch_dir"/*.patch; do
+        local name
+        name="$(basename "$p")"
+
+        # Already applied, e.g. re-running against an existing checkout.
+        if git apply --reverse --check "$p" 2>/dev/null; then
+            info "Already applied, skipping: $name"
+            continue
+        fi
+
+        if ! git apply --check "$p" 2>/dev/null; then
+            error "Patch does not apply cleanly against $BRANCH: $name
+The branch has probably moved on and the patch needs a refresh, or the
+change is already upstream. Re-run with SKIP_PATCHES=1 to build without it."
+        fi
+
+        git apply "$p" 2>&1 | tee -a "$LOG_FILE"
+        ok "Applied: $name"
+    done
 }
 
 # --- Step 3: Configure Kernel ---
@@ -503,6 +552,7 @@ main() {
     preflight
     install_deps
     clone_source
+    apply_patches
     configure_kernel
     build_kernel
     install_kernel

--- a/patches/0001-drm-apple-reconnect-DP2HDMI-output-on-resume.patch
+++ b/patches/0001-drm-apple-reconnect-DP2HDMI-output-on-resume.patch
@@ -1,0 +1,51 @@
+From a0ee8180974f1dc609cf474cb7eb11d0808e440a Mon Sep 17 00:00:00 2001
+From: rgvxsthi <raghavsethi@yandex.com>
+Date: Sat, 25 Jul 2026 19:31:40 +1000
+Subject: [PATCH] drm/apple: reconnect DP2HDMI output on resume
+
+On systems with a built-in HDMI port behind a DP2HDMI bridge,
+dcp_platform_suspend() disables the HPD interrupt and tears the DPTX
+link down. dcp_platform_resume() only re-enables the interrupt.
+
+The HPD interrupt is edge triggered. If the display is left plugged in
+across a suspend/resume cycle there is no edge to trigger it on resume,
+so the link is never re-established and the external display stays dark
+until the cable is physically unplugged and replugged.
+
+Call dcp_enable_dp2hdmi_hpd() from resume instead of a bare
+enable_irq(). It samples the HPD GPIO and calls dcp_dptx_connect() if a
+display is still present before enabling the interrupt, which is the
+same sequence already used from dcp_wait_ready().
+
+Found on a MacBook Pro 14-inch M1 Pro (apple,j314s).
+---
+ drivers/gpu/drm/apple/dcp.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/apple/dcp.c b/drivers/gpu/drm/apple/dcp.c
+index 9dfc3fd002f5..24d5f3e25f60 100644
+--- a/drivers/gpu/drm/apple/dcp.c
++++ b/drivers/gpu/drm/apple/dcp.c
+@@ -1310,8 +1310,18 @@ static int dcp_platform_resume(struct device *dev)
+ {
+ 	struct apple_dcp *dcp = dev_get_drvdata(dev);
+ 
++	/*
++	 * dcp_platform_suspend() tore the DPTX link down. The HPD interrupt is
++	 * edge triggered, so if the display was never physically unplugged
++	 * across suspend there is no edge to re-trigger it on resume and the
++	 * output stays dark until the user replugs the cable.
++	 *
++	 * dcp_enable_dp2hdmi_hpd() samples the HPD GPIO and reconnects if a
++	 * display is still present before re-enabling the interrupt, which is
++	 * exactly what is needed here.
++	 */
+ 	if (dcp->hdmi_hpd_irq)
+-		enable_irq(dcp->hdmi_hpd_irq);
++		dcp_enable_dp2hdmi_hpd(dcp);
+ 
+ 	if (dcp->avep)
+ 		av_service_connect(dcp);
+-- 
+2.55.0
+


### PR DESCRIPTION
Separate from #7 and independent of it — different parts of the script, no conflicts either way.

## The bug

On Macs with a built-in HDMI port, suspending with a monitor attached and waking up leaves the monitor dark. The only recovery is unplugging and replugging the cable. It comes up regularly and is usually described as a known DCP suspend/resume problem with no fix:

- https://discussion.fedoraproject.org/t/hdmi-output-after-suspend-to-ram-on-macbook-pro/101597
- https://github.com/AsahiLinux/docs/issues/94

It turns out to be small and specific. In `drivers/gpu/drm/apple/dcp.c`:

```c
static int dcp_platform_suspend(struct device *dev)
{
	if (dcp->hdmi_hpd_irq) {
		disable_irq(dcp->hdmi_hpd_irq);
		disconnected_hpd_event(dcp->connector);
		dcp_dptx_disconnect(dcp, 0);      // link torn down
	}
}

static int dcp_platform_resume(struct device *dev)
{
	if (dcp->hdmi_hpd_irq)
		enable_irq(dcp->hdmi_hpd_irq);    // ...and that is all
}
```

Suspend tears the DPTX link down, resume only re-enables the hotplug interrupt. That interrupt is **edge triggered** — the driver says so in its own comment above `dcp_enable_dp2hdmi_hpd()`. A display left plugged in across suspend never generates an edge, so the handler never runs and `dcp_dptx_connect()` is never called again. Replugging works because it creates the edge by hand.

Before, on resume, the HDMI DCP says nothing at all:

```
[3094.319] PM: suspend entry (s2idle)
[3094.499] apple-dcp 289c00000.dcp: dcp_dptx_disconnect(port=0)
[3095.442] apple-dcp 38bc00000.dcp: dcp_poweron() starting      <- internal panel only
```

## The fix

The driver already has the right helper. `dcp_enable_dp2hdmi_hpd()` samples the HPD GPIO, calls `dcp_dptx_connect()` if a display is still there, and then enables the interrupt — the same sequence `dcp_wait_ready()` already uses. Resume just was not calling it:

```diff
  	if (dcp->hdmi_hpd_irq)
- 		enable_irq(dcp->hdmi_hpd_irq);
+ 		dcp_enable_dp2hdmi_hpd(dcp);
```

After:

```
[107.729] PM: suspend entry (s2idle)
[108.345] apple-dcp 289c00000.dcp: dcp_dptx_disconnect(port=0)
[108.634] apple-dcp 289c00000.dcp: dcp_enable_dp2hdmi_hpd: DP2HDMI HPD connected:1
[108.634] apple-dcp 289c00000.dcp: dcp_dptx_connect(port=0)
[109.409] PM: suspend exit
```

Display returns with no replug.

## How it is wired in

Since this repo builds a kernel rather than shipping one, the patch goes in a `patches/` directory that the script applies after cloning and before configuring:

- Applied in filename order.
- Already-applied patches are detected with `git apply --reverse --check` and skipped, so re-running against an existing checkout is safe.
- A patch that no longer applies is a hard error, not a silent skip. Quietly building without a fix someone expected seemed worse than stopping.
- `SKIP_PATCHES=1` builds the branch untouched.

That also gives anyone else somewhere to drop their own patches without forking the script.

## Testing

Built and booted on a MacBook Pro 14-inch M1 Pro (`apple,j314s`), Fedora Asahi Remix 44, kernel 7.0.13. Suspend/resume with HDMI connected now restores the display automatically, confirmed over several cycles. GPU still comes up as `Apple M1 Pro (G13S C0)`, and the stock kernels remain bootable.

I also checked the patch applies cleanly to a pristine `fairydust` checkout and is correctly skipped on an already-patched tree.

Worth noting for anyone reading this later: `fairydust` does **not** fix this on its own. Its `dcp.c` is byte-identical to `asahi-wip`. fairydust adds USB-C DisplayPort alt mode, which is a separate output path from the built-in HDMI port.